### PR TITLE
[IMP] account_fiscal_year_closing: Optional chart template

### DIFF
--- a/account_fiscal_year_closing/models/account_fiscalyear_closing_template.py
+++ b/account_fiscal_year_closing/models/account_fiscalyear_closing_template.py
@@ -19,7 +19,6 @@ class AccountFiscalyearClosingTemplate(models.Model):
     chart_template_ids = fields.Many2many(
         comodel_name="account.chart.template",
         string="Available for",
-        required=True,
     )
 
 


### PR DESCRIPTION
Otherwise, the following happens:
1. Install `account`,
    verify that no chart of accounts is set in Accounting > Configuration > Settings.
2. Create accounts, registries and customers,
3. Create and confirm an invoice,
    verify that it is no longer possible to set up the chart of accounts.
4. Create a closing template without selecting any chart of accounts template

**Expected**
The closing template is created
**Current**
![image](https://github.com/user-attachments/assets/bf6d2411-b8d3-4a26-8065-1ac07f57080d)
